### PR TITLE
Sender side thinning

### DIFF
--- a/implementation/config.py
+++ b/implementation/config.py
@@ -69,16 +69,16 @@ def main():
 #include <rte_common.h>
 struct Params params = {{
     .index = {0},
-    .BDP = 20,
-    .small_flow_thre = 20,
+    .BDP = 773,
+    .small_flow_thre = 773,
     .mss = 1460,
     .priority_limit = 6,
     .bandwidth = 10000000000, //10Gbps
     .ip = {1},
-    .pim_beta = 5,
+    .pim_beta = 3,
     .pim_alpha = 1.1,
     .pim_iter_limit = 1,
-    .propagation_delay = 0.0000002,
+    .propagation_delay = 0.0000565,
     .clock_bias = 0.0000005,
     .send_port = 0,
     .pim_select_min_iters = 0,

--- a/implementation/src/header.h
+++ b/implementation/src/header.h
@@ -19,6 +19,8 @@
 #define PIM_FLOW_SYNC_ACK 9
 // #define PIM_FIN_SYNC_ACK 10
 #define PIM_FIN_ACK 10
+//RTS_PERMIT packet to act as recurring notify packet.
+#define PIM_RTS_PERMIT 11
 #define MSS 1460
 
 // ------- PIM -----
@@ -49,8 +51,8 @@ struct pim_rts_hdr {
 
 struct pim_grant_hdr {
 	uint32_t epoch;
-	uint8_t iter;
 	uint32_t remaining_sz;
+	uint8_t iter;
 	uint8_t prompt;
 };
 

--- a/implementation/src/pim_host.h
+++ b/implementation/src/pim_host.h
@@ -58,6 +58,9 @@ struct pim_epoch {
 	struct pim_rts rts_q[PIM_NUM_HOST];
 	uint32_t grant_size;
 	uint32_t rts_size;
+	//Hold permit addresses
+	uint32_t permit_q[PIM_NUM_HOST];
+	int permit_q_size;
 	bool grant_bmp[PIM_NUM_HOST];
 	bool rts_bmp[PIM_NUM_HOST];
 	struct pim_rts* min_rts;

--- a/implementation/src/utils.c
+++ b/implementation/src/utils.c
@@ -3,22 +3,17 @@
 #include <string.h>
 #include <stdlib.h>
 
-void shuffle_inplace(void *list, size_t n, size_t size) {
-    char tmp[size];
-    char *arr = list;
-    size_t stride = size * sizeof(char);
-
+void shuffle_inplace(void *array, size_t n, size_t elsize) {
     if (n <= 1) {
-        return;
+            return;
     }
-
-    size_t i;
-    for (i = 0; i < n - 1; ++i) {
-        size_t rnd = (size_t) rand();
-        size_t j = i + rnd / (RAND_MAX / (n - i) + 1);
-
-        memcpy(tmp, arr + j * stride, size);
-        memcpy(arr + j * stride, arr + i * stride, size);
-        memcpy(arr + i * stride, tmp, size);
+    char tmp[elsize];
+    char *arr = array;
+    size_t stride = elsize * sizeof(char);
+    for (size_t i = n-1; i > 0; --i) {
+            size_t j = ((size_t) rand()) % (i + 1);
+            memcpy(tmp, arr + i * stride, elsize);
+            memcpy(arr + i * stride, arr + j * stride, elsize);
+            memcpy(arr + j * stride, tmp, elsize);
     }
 }

--- a/implementation/src/utils.h
+++ b/implementation/src/utils.h
@@ -1,9 +1,10 @@
 #ifndef _UTILS_H
 #define _UTILS_H
-//#include <rte_random.h>
 #include <string.h>
 #include <stddef.h>
-/*Given a list of n elements in contigous memory,
-* permute the list inplace using the Fisher-Yates algorithm.*/
+/*
+Given a `list` of `n` elements in contigous memory,
+permute the list inplace using the Fisher-Yates algorithm.
+*/
 void shuffle_inplace(void *list, size_t n, size_t el_size);
 #endif


### PR DESCRIPTION
1)Fixed propagation delay values to measured values on testbed.
2)Implements sender side thinning by sending PIM_PERMIT packets. This packet performs the role of the recurring NOTIFY needed within the storm protocol.